### PR TITLE
fix command spelling mistake

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cd api
 composer install
 npm install
 php artisan migrate --seed
-php aritsan passport:install
+php artisan passport:install
 
 ```
 


### PR DESCRIPTION
I noticed that the command in the README file was incorrect, so I made a change to correct it. The updated command is now correct and should work as intended. I tested the command to ensure that it was functioning properly. Please review and merge this pull request if the changes are acceptable.